### PR TITLE
vaaman: Cleanup and minor fixes

### DIFF
--- a/conf/machine/include/vicharak-common.inc
+++ b/conf/machine/include/vicharak-common.inc
@@ -83,7 +83,6 @@ IMAGE_INSTALL:append = " \
 	libxfce4util \
 	xfce4-calculator-plugin \
 	xfce4-screensaver \
-	chromium-x11 \
 "
 
 # Enable systemd support

--- a/conf/machine/rk3399-vaaman.conf
+++ b/conf/machine/rk3399-vaaman.conf
@@ -10,6 +10,7 @@ require conf/machine/include/vicharak-common.inc
 KERNEL_DEVICETREE = "rockchip/rk3399-vaaman-linux.dtb"
 PREFERRED_VERSION_linux-rockchip = "5.10%"
 LINUXLIBCVERSION = "5.10-vicharak%"
+DISPLAY_PLATFORM = "x11"
 
 UBOOT_MACHINE = "rk3399-vaaman_defconfig"
 

--- a/recipes-bsp/rk-binary/rk-binary-native.bb
+++ b/recipes-bsp/rk-binary/rk-binary-native.bb
@@ -8,7 +8,7 @@ DESCRIPTION = "Rockchip binary tools"
 LICENSE = "LICENSE.rockchip"
 LIC_FILES_CHKSUM = "file://${RKBASE}/licenses/LICENSE.rockchip;md5=d63890e209bf038f44e708bbb13e4ed9"
 SRC_URI = " \
-	git://github.com/vicharak-in/rockchip-linux-rkbin.git;protocol=https;branch=master;name=rkbin;destsuffix=rkbin; \
+	git://github.com/vicharak-in/rockchip-linux-rkbin.git;protocol=https;branch=master;name=rkbin;destsuffix=rkbin \
 	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=tools;name=tools;destsuffix=extra \
 "
 

--- a/recipes-bsp/rockchip-npu/rockchip-npu.bb
+++ b/recipes-bsp/rockchip-npu/rockchip-npu.bb
@@ -12,7 +12,7 @@ RDEPENDS:${PN} = "bash"
 inherit local-git
 
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=rknpu-fw; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=rknpu-fw \
 	file://rockchip-npu.sh \
 "
 SRCREV = "2a532b012b5179dd573d8b7f98fc2c51b3046409"

--- a/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
+++ b/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://END_USER_LICENCE_AGREEMENT.txt;md5=3918cc9836ad038c5a
 inherit local-git
 
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=libmali; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=libmali \
 "
 SRCREV = "309268f7a34ca0bba0ab94a0b09feb0191c77fb8"
 S = "${WORKDIR}/git"

--- a/recipes-graphics/rockchip-librga/rockchip-librga.bb
+++ b/recipes-graphics/rockchip-librga/rockchip-librga.bb
@@ -14,7 +14,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit local-git
 
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=linux-rga-multi; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=linux-rga-multi \
 "
 SRCREV = "c6105b06ade0e5dc7f16924c7f0f5e9dcdb198bc"
 S = "${WORKDIR}/git"

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -4,7 +4,7 @@
 DEPENDS:append = " automake-native autoconf-native util-macros-native font-util-native xtrans-native libxshmfence rockchip-librga"
 
 SRCREV = "${AUTOREV}"
-SRC_URI:append = " git://github.com/JeffyCN/xorg-xserver;protocol=https;nobranch=1;branch=${PV}_2023_07_18;"
+SRC_URI:append = " git://github.com/JeffyCN/xorg-xserver;protocol=https;nobranch=1;branch=${PV}_2023_07_18"
 SRC_URI:remove = "https://www.x.org/releases//individual/xserver/xorg-server-${PV}.tar.bz2"
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_4.4-custom.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_4.4-custom.bb
@@ -9,7 +9,7 @@ inherit local-git
 
 SRCREV = "f207a103477d8c601d89db381f07246d6942d9d0"
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-2022_06_27; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-2022_06_27 \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10-custom.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10-custom.bb
@@ -9,7 +9,7 @@ inherit local-git
 
 SRCREV = "72de5a560a44fb81549f1da325a1b3e323a7aaf7"
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-5.10-2022_01_10; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-5.10-2022_01_10 \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux-rockchip_4.4.bb
+++ b/recipes-kernel/linux/linux-rockchip_4.4.bb
@@ -8,7 +8,7 @@ inherit local-git
 
 SRCREV = "e7a4fc70448ca2f66b3df50cabe527916b42bdad"
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-4.4-2022_11_23; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=kernel-4.4-2022_11_23 \
 	file://${THISDIR}/files/cgroups.cfg \
 "
 

--- a/recipes-kernel/linux/linux-rockchip_5.10.bb
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bb
@@ -7,9 +7,9 @@ require linux-rockchip.inc
 inherit local-git
 
 #SRCREV = "938df9cf0910f8f225d85f06b52be7f615857aa8"
-SRCREV = "8685847a83d879cf66ec099c567233df3c832cac"
+SRCREV = "be156a25abd0879c5f168bad724ad1eb1e2636bf"
 SRC_URI = " \
-	git://github.com/vicharak-in/vicharak-linux-kernel.git;protocol=https;branch=master; \
+	git://github.com/vicharak-in/vicharak-linux-kernel.git;protocol=https;branch=master \
 	file://${THISDIR}/files/cgroups.cfg \
 	file://${THISDIR}/files/rk3588_axon.cfg \
 	file://${THISDIR}/files/ext4.cfg \

--- a/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
+++ b/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
@@ -12,11 +12,12 @@ SRC_URI = "git://github.com/radxa/rkwifibt.git;protocol=https;branch=develop"
 S = "${WORKDIR}/git"
 
 inherit allarch deploy
-RPROVIDES_${PN}-scripts += "rkwifibit-firmware-rtl8852bs-bt"
+RPROVIDES_${PN}-scripts += "rkwifibt-firmware-rtl8822cs-bt rkwifibit-firmware-rtl8852bs-bt"
 
 do_install() {
     install -d ${D}/lib/firmware/rtlbt/
-   	install -m 0644 ${S}/firmware/realtek/RTL8852BS/* -t ${D}/lib/firmware/rtlbt/
+    install -m 0644 ${S}/firmware/realtek/RTL8822CS/* -t ${D}/lib/firmware/rtlbt/
+    install -m 0644 ${S}/firmware/realtek/RTL8852BS/* -t ${D}/lib/firmware/rtlbt/
     cp -u $(find ${S}/firmware/ -type f) ${D}/lib/firmware/
 #    ln -rsf ${D}/lib/firmware/*rtl*_* ${D}/lib/firmware/rtlbt/
 }
@@ -38,6 +39,7 @@ PACKAGES =+ " \
 	${PN}-rtl8723du-bt \
 	${PN}-rtl8821cu-bt \
 	${PN}-rtl8852bs-bt \
+	${PN}-rtl8822cs-bt \
 "
 
 FILES:${PN}-ap6212a1-wifi = " \

--- a/recipes-multimedia/alsa/rockchip-alsa-config.bb
+++ b/recipes-multimedia/alsa/rockchip-alsa-config.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://NOTICE;md5=9645f39e9db895a4aa6e02cb57294595"
 inherit local-git
 
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=alsa-config; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=alsa-config \
 "
 SRCREV = "1e0c4b5382b84ed629b1ca9e40c814103b92ee93"
 S = "${WORKDIR}/git"

--- a/recipes-multimedia/gstreamer-rockchip/gstreamer1.0-rockchip.bb
+++ b/recipes-multimedia/gstreamer-rockchip/gstreamer1.0-rockchip.bb
@@ -15,7 +15,7 @@ DEPENDS:append = " gstreamer1.0-plugins-base"
 inherit local-git
 
 SRCREV = "2ed1e68b0aa77728b1d493344d8e62a04b1b64e0"
-SRC_URI = "git://github.com/JeffyCN/mirrors.git;protocol=https;branch=gstreamer-rockchip;"
+SRC_URI = "git://github.com/JeffyCN/mirrors.git;protocol=https;branch=gstreamer-rockchip"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/rockchip-mpp/rockchip-mpp.bb
+++ b/recipes-multimedia/rockchip-mpp/rockchip-mpp.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
 inherit local-git
 
 SRCREV = "0de995aa8b98f0be666af18a0e0bb9dcec462039"
-SRC_URI = "git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=mpp-dev-2023_04_19;"
+SRC_URI = "git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=mpp-dev-2023_04_19"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/rockchip-rkaiq/rockchip-rkaiq.bb
+++ b/recipes-multimedia/rockchip-rkaiq/rockchip-rkaiq.bb
@@ -17,7 +17,7 @@ inherit local-git
 
 SRCREV = "be96b36bab4c3533f7cd011385539b565578ab8b"
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=rkaiq-2023_04_04; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;nobranch=1;branch=rkaiq-2023_04_04 \
 	file://rkaiq_daemons.sh \
 "
 

--- a/recipes-multimedia/rockchip-rkisp/rockchip-rkisp.bb
+++ b/recipes-multimedia/rockchip-rkisp/rockchip-rkisp.bb
@@ -16,7 +16,7 @@ inherit local-git
 
 SRCREV = "fafcd69874d20a7737425cc16a70619b220f8a2e"
 SRC_URI = " \
-	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=camera_engine_rkisp; \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=camera_engine_rkisp \
 	file://rkisp_daemons.sh \
 "
 


### PR DESCRIPTION
This PR adds the following four commits:
1. Mickledore doesn't have support for chromium so the chromium-x11 recipe has been removed from IMAGE_INSTALL.
2. DISPLAY_PALTFORM has been set to prevent crashes related to xserver-xorg.
3. Firmware support has been added for rtl8822cs chip used in vaaman.
4. Syntax issues have been fixed which were interfering with the build