### PR TITLE
recipes-kernel: linux-rockchip: Switch SRCREV to AUTOREV

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10.bb
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bb
@@ -6,8 +6,7 @@ require linux-rockchip.inc
 
 inherit local-git
 
-SRCREV = "60704737f1be3e10d03c6194d53eb5fc2c0d4dcf"
-
+SRCREV = "${AUTOREV}"
 SRC_URI = " \
 	git://github.com/vicharak-in/vicharak-linux-kernel.git;protocol=https;branch=master \
 	file://${THISDIR}/files/cgroups.cfg \


### PR DESCRIPTION
Change the SRCREV from a fixed git commit hash to AUTOREV to always fetch the latest commit from the master branch during builds.