### PR TITLE
Add u-boot-update to rockchip.sh to generate extlinux.conf during first boot

### DIFF
--- a/recipes-init/rockchip-init/files/rockchip.sh
+++ b/recipes-init/rockchip-init/files/rockchip.sh
@@ -21,6 +21,7 @@ start() {
     touch "$FIRST_BOOT_FILE"
     
     /usr/sbin/rk-resize-helper start
+    /usr/bin/u-boot-update
     echo "first-boot configured Successfully " > /dev/"${CONSOLE_DEV}"
 }
 


### PR DESCRIPTION
To add kernel arguments, users need to edit the u-boot-update file. I've updated the init process by adding u-boot-update to rockchip.sh so that u-boot-update gets called on first boot and these kernel arguments are applied to extlinux.conf.