### PR TITLE
rockchip-init: mountboot: Check if /boot is mounted before mounting

### DIFF
--- a/recipes-init/rockchip-mount/files/mountboot.sh
+++ b/recipes-init/rockchip-mount/files/mountboot.sh
@@ -14,10 +14,15 @@ dev=$(__get_block_dev)
 
 boot_part=$(parted -s "${dev}" print | grep -w "boot" | awk '{print $1}')
 
-# Mount the boot partition
-echo "Mounting boot partition  ${dev}p${boot_part} to /boot"
-mount "${dev}p${boot_part}" /boot
+# Mount the boot partition only if /boot is not already mounted
+if mountpoint -q /boot; then
+        echo "/boot is already mounted, skipping mount."
+else
+        echo "Mounting boot partition ${dev}p${boot_part} to /boot"
+        mount "${dev}p${boot_part}" /boot
+        echo "Mount operation completed successfully."
+fi
 
-mkdir -p /boot/overlays-$(uname -r)
+mkdir -p "/boot/overlays-$(uname -r)"
 
-echo "Mount operation completed successfully."
+echo "Directory /boot/overlays-$(uname -r) ensured."


### PR DESCRIPTION
Added a check to ensure /boot is not already mounted before attempting to mount the boot partition.