### PR TITLE
machine: boot: fix boot partition mounting by mounting boot-vfat.img

### DIFF
--- a/conf/machine/include/rockchip-common.inc
+++ b/conf/machine/include/rockchip-common.inc
@@ -173,7 +173,7 @@ gen_rkupdateimg() {
 
 	cd "${IMGDEPLOYDIR}"
 
-	RK_IMAGES="loader.bin uboot.env uboot.img trust.img boot.img"
+	RK_IMAGES="loader.bin uboot.env uboot.img trust.img boot.img boot-vfat.img"
 
 	# Create temporary symlinks, because the tool would crash with abs pathes
 	for img in ${RK_IMAGES};do
@@ -195,6 +195,7 @@ gen_rkupdateimg() {
 			uboot-env) IMAGE="uboot.env" ;;
 			backup) echo "backup RESERVED" >> "${OUT}"; continue ;;
 			system|system_[ab]) IMAGE="rootfs.img" ;;
+                        boot) IMAGE="boot-vfat.img" ;;
 			*_a) IMAGE="${NAME%_a}.img" ;;
 			*_b) IMAGE="${NAME%_b}.img" ;;
 			*) IMAGE="${NAME}.img" ;;

--- a/wic/rk3399-vaaman.wks
+++ b/wic/rk3399-vaaman.wks
@@ -1,12 +1,9 @@
-# Copyright (c) 2019, Fuzhou Rockchip Electronics Co., Ltd
-# Released under the MIT license (see COPYING.MIT for the terms)
-#
-# long-description: Creates a GPT disk image for Rockchip boards
+# Rockchip RK3399 Vaaman - vfat boot partition
 
-# 0~32K: gpt
 bootloader --ptable gpt
 part --source rawcopy --sourceparams="file=idblock.img" --align 32 --no-table
 part --source rawcopy --sourceparams="file=uboot.img" --part-name uboot --align 8192 --no-table
 part --source rawcopy --sourceparams="file=trust.img" --part-name trust --no-table
 part /boot --no-fstab-update --use-uuid --source bootimg-partition --fstype vfat --label boot --size 128M
-part / --source rootfs --fstype ${RK_ROOTFS_TYPE} --part-name rootfs --uuid ${RK_ROOTDEV_UUID} --align 8192
+part / --source rootfs --fstype ext4 --part-name rootfs --uuid 614e0000-0000-4b53-8000-1d28000054a9 --align 8192
+


### PR DESCRIPTION
Should not use the android parition by default when booting up from the eMMC.